### PR TITLE
Take into account reflexive nodes when drawing the dependencies graph.

### DIFF
--- a/ida_plugin/uefi_analyser/dep_graph.py
+++ b/ida_plugin/uefi_analyser/dep_graph.py
@@ -119,6 +119,9 @@ class DependencyGraph(ida_graph.GraphViewer):
             if output_node is None:
                 output_node = self.AddNode((pair[0], self.color))
                 saved_nodes.append((pair[0], output_node))
+            if pair[0] == pair[1]:
+                # Handle the reflexive case, e.g. (x, x)
+                input_node = output_node
             if input_node is None:
                 input_node = self.AddNode((pair[1], self.color))
                 saved_nodes.append((pair[1], input_node))


### PR DESCRIPTION
Attempt to remediate #12. I'm not super-familiar with the IDAPython API so perhaps there's a more straightforward method to handle these cases. LMK what you think :)

ArpDxe before:
![image](https://user-images.githubusercontent.com/8438963/77101632-4a85c580-6a20-11ea-9dbe-1c29e395b366.png)

ArpDxe after:
![image](https://user-images.githubusercontent.com/8438963/77101655-52456a00-6a20-11ea-8b3b-c96829b39ec2.png)
